### PR TITLE
feature: select env-s in which the scaffold runs.

### DIFF
--- a/config/scaffold.php
+++ b/config/scaffold.php
@@ -1,6 +1,17 @@
 <?php
 
 return [
+
+    /*
+    |--------------------------------------------------------------------
+    | Allowed environments
+    |--------------------------------------------------------------------
+    |
+    | Here is where you can register your allowed env-s.
+    | By default is ['local']
+    |
+    */
+
     'env' => [
         'local',
     ],

--- a/config/scaffold.php
+++ b/config/scaffold.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'env' => [
+        'local',
+    ],
+];

--- a/src/Http/Middleware/ScaffoldMiddleware.php
+++ b/src/Http/Middleware/ScaffoldMiddleware.php
@@ -5,7 +5,7 @@ namespace Amranidev\ScaffoldInterface\Http\Middleware;
 use Closure;
 
 /**
- * class ScaffoldMiddleware
+ * class ScaffoldMiddleware.
  *
  * @author Athi Krishnan <athikrishnan5@gmail.com>
  */
@@ -15,7 +15,7 @@ class ScaffoldMiddleware
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
+     * @param  \Closure                  $next
      * @return mixed
      */
     public function handle($request, Closure $next)
@@ -23,10 +23,12 @@ class ScaffoldMiddleware
         if ($request->segment(1) == 'scaffold') {
 
             // allowed env-s check
-            $allowed  = collect(config('scaffold.env'))
+            $allowed = collect(config('scaffold.env'))
                             ->contains(config('app.env'));
 
-            if( ! $allowed) return redirect('/');
+            if(!$allowed) {
+                return redirect('/');
+            }
         }
 
         return $next($request);

--- a/src/Http/Middleware/ScaffoldMiddleware.php
+++ b/src/Http/Middleware/ScaffoldMiddleware.php
@@ -4,6 +4,11 @@ namespace Amranidev\ScaffoldInterface\Http\Middleware;
 
 use Closure;
 
+/**
+ * class ScaffoldMiddleware
+ *
+ * @author Athi Krishnan <athikrishnan5@gmail.com>
+ */
 class ScaffoldMiddleware
 {
     /**
@@ -16,13 +21,12 @@ class ScaffoldMiddleware
     public function handle($request, Closure $next)
     {
         if ($request->segment(1) == 'scaffold') {
-            
+
+            // allowed env-s check
             $allowed  = collect(config('scaffold.env'))
                             ->contains(config('app.env'));
 
-            if( ! $allowed) {
-                return redirect('/');
-            }
+            if( ! $allowed) return redirect('/');
         }
 
         return $next($request);

--- a/src/Http/Middleware/ScaffoldMiddleware.php
+++ b/src/Http/Middleware/ScaffoldMiddleware.php
@@ -16,6 +16,7 @@ class ScaffoldMiddleware
      *
      * @param \Illuminate\Http\Request $request
      * @param \Closure                 $next
+     * 
      * @return mixed
      */
     public function handle($request, Closure $next)

--- a/src/Http/Middleware/ScaffoldMiddleware.php
+++ b/src/Http/Middleware/ScaffoldMiddleware.php
@@ -14,8 +14,8 @@ class ScaffoldMiddleware
     /**
      * Handle an incoming request.
      *
-     * @param \Illuminate\Http\Request  $request
-     * @param \Closure                  $next
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
      * @return mixed
      */
     public function handle($request, Closure $next)

--- a/src/Http/Middleware/ScaffoldMiddleware.php
+++ b/src/Http/Middleware/ScaffoldMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Amranidev\ScaffoldInterface\Http\Middleware;
+
+use Closure;
+
+class ScaffoldMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if ($request->segment(1) == 'scaffold') {
+            
+            $allowed  = collect(config('scaffold.env'))
+                            ->contains(config('app.env'));
+
+            if( ! $allowed) {
+                return redirect('/');
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/ScaffoldMiddleware.php
+++ b/src/Http/Middleware/ScaffoldMiddleware.php
@@ -16,7 +16,7 @@ class ScaffoldMiddleware
      *
      * @param \Illuminate\Http\Request $request
      * @param \Closure                 $next
-     * 
+     *
      * @return mixed
      */
     public function handle($request, Closure $next)

--- a/src/Http/Middleware/ScaffoldMiddleware.php
+++ b/src/Http/Middleware/ScaffoldMiddleware.php
@@ -14,8 +14,8 @@ class ScaffoldMiddleware
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure                  $next
+     * @param \Illuminate\Http\Request  $request
+     * @param \Closure                  $next
      * @return mixed
      */
     public function handle($request, Closure $next)
@@ -26,7 +26,7 @@ class ScaffoldMiddleware
             $allowed = collect(config('scaffold.env'))
                             ->contains(config('app.env'));
 
-            if(!$allowed) {
+            if (!$allowed) {
                 return redirect('/');
             }
         }

--- a/src/ScaffoldInterfaceServiceProvider.php
+++ b/src/ScaffoldInterfaceServiceProvider.php
@@ -26,6 +26,10 @@ class ScaffoldInterfaceServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        // middleware configuration
+        $this->publishes([
+            __DIR__.'/../config/scaffold.php' => config_path('scaffold.php'),
+        ]);
 
         // Get namespace.
         $nameSpace = $this->app->getNamespace();


### PR DESCRIPTION
Allow the user to select environments in which the /scaffold url's will be allowed.

requires the following middleware to be added to global HTTP middleware stack.

```
\Amranidev\ScaffoldInterface\Http\Middleware\ScaffoldMiddleware::class,
```

and the environments are selected under 

```
config\scaffold.php
```