### PR TITLE
Update scaffoldapp.blade.php to fix spelling error

### DIFF
--- a/resources/views/scaffoldApp.blade.php
+++ b/resources/views/scaffoldApp.blade.php
@@ -173,7 +173,7 @@
             <ul>
                 <li><a href = "{{URL::to('/')}}/dashboard" class="btn-floating blue tooltipped" data-position="left" data-delay="50" data-tooltip="Dashboard"><i class="material-icons">view_list</i></a></li>
                 <li><a href = "{{URL::to('/')}}/scaffold/rollback" class="btn-floating pink tooltipped" data-position="left" data-delay="50" data-tooltip="RollBack the Schema"><i class="material-icons">repeat</i></a></li>
-                <li><a href = "{{URL::to('/')}}/scaffold/migrate" class="btn-floating orange tooltipped" data-position="left" data-delay="50" data-tooltip="Migrate the Shcema"><i class="material-icons">input</i></a></li>
+                <li><a href = "{{URL::to('/')}}/scaffold/migrate" class="btn-floating orange tooltipped" data-position="left" data-delay="50" data-tooltip="Migrate the Schema"><i class="material-icons">input</i></a></li>
             </ul>
         </div>
         <div id="modal1" class="modal">


### PR DESCRIPTION
On line 176 changed:
<li><a href = "{{URL::to('/')}}/scaffold/migrate" class="btn-floating orange tooltipped" data-position="left" data-delay="50" data-tooltip="Migrate the Shcema"><i class="material-icons">input</i></a></li>

into

<li><a href = "{{URL::to('/')}}/scaffold/migrate" class="btn-floating orange tooltipped" data-position="left" data-delay="50" data-tooltip="Migrate the Schema"><i class="material-icons">input</i></a></li>